### PR TITLE
Update motion.initd

### DIFF
--- a/pi_motion/motion.initd
+++ b/pi_motion/motion.initd
@@ -52,6 +52,7 @@ case "$1" in
   start)
     if check_daemon_enabled ; then
 	if [ -e "$CAMERA" ]; then
+	    sleep 30
             if ! [ -d /var/run/motion ]; then
                 mkdir -m 02750 /var/run/motion
                 chown motion:motion /var/run/motion


### PR DESCRIPTION
add 30 second sleep before starting the daemon.  resolves the issue where the camera  feed does not starting sometimes after a reboot or power up.